### PR TITLE
added shortcodes for direct use in posts

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -13,6 +13,7 @@
 function get_the_github_view_link() {
 	return '<a href="' . get_the_github_view_url() . '">' . apply_filters( 'wpghs_view_link_text', 'View this post on GitHub.' ) . '</a>';
 }
+add_shortcode( 'get_the_github_view_link', 'get_the_github_view_link' );
 
 /**
  * Returns the URL to view the current post on GitHub.
@@ -24,6 +25,7 @@ function get_the_github_view_url() {
 
 	return $wpghs_post->github_view_url();
 }
+add_shortcode( 'get_the_github_view_url', 'get_the_github_view_url' );
 
 /**
  * Returns the HTML markup to edit the current post on GitHub.
@@ -33,6 +35,7 @@ function get_the_github_view_url() {
 function get_the_github_edit_link() {
 	return '<a href="' . get_the_github_edit_url() . '">' . apply_filters( 'wpghs_edit_link_text', 'Edit this post on GitHub.' ) . '</a>';
 }
+add_shortcode( 'get_the_github_edit_link', 'get_the_github_edit_link' );
 
 /**
  * Returns the URL to edit the current post on GitHub.
@@ -44,3 +47,4 @@ function get_the_github_edit_url() {
 
 	return $wpghs_post->github_edit_url();
 }
+add_shortcode( 'get_the_github_edit_url', 'get_the_github_edit_url' );


### PR DESCRIPTION
`shortcode`s seem like an easy addition here, allowing direct use in individual posts via `[get_the_github_view_link]`. Seems cleaner than adding it to the default theme for all posts if that's not what you want. Tested on my WP site and works. Official unit tests not performed.
